### PR TITLE
filter properties by category, add list of allowed property categories

### DIFF
--- a/src/controllers/propertyController.ts
+++ b/src/controllers/propertyController.ts
@@ -109,7 +109,22 @@ export default class PropertyController {
 
   public static async fetchAll (req, res) {
     try {
-      const properties = await Property.findAll();
+      const { category } = req.query;
+      let whereQuery = {}
+      if (category) {
+         whereQuery = { where: {
+          category
+        }}
+      }
+
+      const properties = await Property.findAll(whereQuery);
+
+      if (properties.length === 0) {
+        return res.status(404).json({
+          message: 'No Property Found',
+        });
+
+      }
 
       return res.status(200).json({
         message: 'Properties returned successfully',

--- a/src/middleware/validation/schemas/propertySchema.ts
+++ b/src/middleware/validation/schemas/propertySchema.ts
@@ -5,7 +5,8 @@ const description = Joi.string().trim().min(3).required();
 const propertyType = Joi.string().trim().min(3).max(20);
 const address = Joi.string().trim().min(3).max(200).required();
 const features = Joi.array();
-const category = Joi.string().trim().min(3).max(30).required();
+// const category = Joi.string().trim().min(3).max(30).required();
+const category = Joi.string().valid('rent', 'lease', 'sale', 'short-let').required();
 const available = Joi.boolean();
 
 export const addPropertySchema = Joi.object({

--- a/src/tests/properties.ts
+++ b/src/tests/properties.ts
@@ -189,7 +189,7 @@ describe('properties tests', () => {
   });
 
   describe('fetch properties', () => {
-    it('returns exisitng properties', (done) => {
+    it('returns existing properties', (done) => {
       chai.request(app)
         .get('/properties')
         .end((err, res) => {
@@ -198,6 +198,39 @@ describe('properties tests', () => {
           done();
         });
     });
+
+    it('returns existing properties by category', (done) => {
+      chai.request(app)
+        .post('/properties')
+        .set('token', token)
+        .send({
+          name: 'New property',
+          description: 'Random description',
+          address: 'Random address',
+          propertyType: 'commercial',
+          category: 'lease',
+      }).end((err, res) => {
+        chai.request(app)
+        .get('/properties?category=lease')
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.properties.length.should.eq(1);
+          done();
+        });
+      })
+      
+    });
+
+    it('returns 404 when property isn\'t found', (done) => {
+      chai.request(app)
+        .get('/properties?category=random')
+        .end((err, res) => {
+          res.should.have.status(404);
+          res.body.message.should.eq('No Property Found');
+          done();
+        });
+    });
+
   });
 
   describe('delete properties', () => {

--- a/src/tests/properties.ts
+++ b/src/tests/properties.ts
@@ -215,6 +215,10 @@ describe('properties tests', () => {
         .end((err, res) => {
           res.should.have.status(200);
           res.body.properties.length.should.eq(1);
+          res.body.properties[0].name.should.eq('New property');
+          res.body.properties[0].description.should.eq('Random description');
+          res.body.properties[0].propertyType.should.eq('commercial');
+          res.body.properties[0].category.should.eq('lease');
           done();
         });
       })


### PR DESCRIPTION
#### What does this PR do?
- Allows a user to fetch Properties by Category

#### Description of Task to be completed?
- Allows users to use a query string to retrieve all properties belonging to a category

#### How should this be manually tested?
curl --location --request GET 'localhost:5000/properties?category=rent' \
--header 'token: {YOUR_TOKEN}' \
--data-raw ''

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?(if applicable)
https://www.pivotaltracker.com/story/show/172163148